### PR TITLE
Fix catch-all email

### DIFF
--- a/dialplan/extensions_custom.conf
+++ b/dialplan/extensions_custom.conf
@@ -6,7 +6,7 @@ same => n,Set(FROMUSER=${CUT(FROMUSER,:,2)})
 same => n,Set(TODEVICE=${DB(DEVICE/${EXTEN}/dial)})
 same => n,Set(TODEVICE=${TOLOWER(${STRREPLACE(TODEVICE,"/",":")})})
 same => n,MessageSend(${TODEVICE},${FROMUSER})
-same => n,ExecIf($["${MESSAGE_SEND_STATUS}" == "FAILURE"]?Goto(messages,mail-${EXTEN},1))
+same => n,ExecIf($["${MESSAGE_SEND_STATUS}" == "FAILURE"]?Goto(mail-${EXTEN},1))
 same => n,Hangup()
 
 ; This could be improved. Any undeliverable SMS just gets sent to a catch-all email address. You


### PR DESCRIPTION
Remove "message" extension so that it jumps to the catch-all email extension within the current extension.  Now, if one of my configure SMS extensions is not available it will jump to my catch-all email, which is exactly what I want.  I am assuming this was how it was intended to work?

Thank you for this very useful script.